### PR TITLE
Add PHP-8.1 and PHP-8.2 tests in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:
@@ -34,13 +34,8 @@ jobs:
       - name: Validate composer.json and composer.lock
         run: composer validate
 
-      - name: Install dependencies for PHP 7
-        if: matrix.php-versions < '8.0'
+      - name: Install dependencies for PHP
         run: composer update --prefer-dist --no-progress
-
-      - name: Install dependencies for PHP 8
-        if: matrix.php-versions >= '8.0'
-        run: composer update --prefer-dist --no-progress --ignore-platform-req=php
 
       - name: Run test suite
         run: composer check

--- a/src/ZipResponder.php
+++ b/src/ZipResponder.php
@@ -4,7 +4,6 @@ namespace Selective\Http\Zip;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use UnexpectedValueException;
 
 /**
  * A HTTP ZIP response provider.
@@ -57,7 +56,7 @@ final class ZipResponder
      * @param string $outputName The output name
      * @param bool $attachment The Content-Disposition header
      *
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      *
      * @return ResponseInterface The response
      */
@@ -72,7 +71,7 @@ final class ZipResponder
         $stream = fopen('php://temp', 'r+');
 
         if (!$stream) {
-            throw new UnexpectedValueException('Stream could not be created');
+            throw new \UnexpectedValueException('Stream could not be created');
         }
 
         fwrite($stream, $content);

--- a/tests/ZipResponderTest.php
+++ b/tests/ZipResponderTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use PhpZip\ZipFile;
 use Selective\Http\Zip\Stream\CallbackStream;
 use Selective\Http\Zip\ZipResponder;
-use ZipArchive;
 use ZipStream\Option\Archive;
 use ZipStream\ZipStream;
 
@@ -116,8 +115,8 @@ class ZipResponderTest extends TestCase
     {
         $filename = __DIR__ . '/temp.zip';
 
-        $zip = new ZipArchive();
-        $zip->open($filename, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip = new \ZipArchive();
+        $zip->open($filename, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
         $zip->addFromString('test.txt', 'my content');
         $zip->close();
 


### PR DESCRIPTION
# Changed log

- Add `PHP-8.1` and `PHP-8.2` version tests in the GitHub action.
- Apply coding style fix via the PHP-CS-Fixer.